### PR TITLE
Remove 'Program Files' module path from Add-WindowsPSModulePath function

### DIFF
--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -695,14 +695,24 @@ function Add-WindowsPSModulePath
         return
     }
 
-    $WindowsPSModulePath = [System.Environment]::GetEnvironmentVariable("psmodulepath", [System.EnvironmentVariableTarget]::Machine)
-    if (-not ($env:PSModulePath).Contains($WindowsPSModulePath))
+    $WindowsPSModulePath = [System.Environment]::GetEnvironmentVariable("PSModulePath", [System.EnvironmentVariableTarget]::Machine)
+    if (-not $env:PSModulePath.Contains($WindowsPSModulePath))
     {
-        $env:PSModulePath += ";${env:userprofile}\Documents\WindowsPowerShell\Modules;${WindowsPSModulePath}"
+        $env:PSModulePath += ";${WindowsPSModulePath}"
     }
 
-    if (-not $env:PSModulePath.Contains('C:\Program Files\WindowsPowerShell\Modules'))
+    if (-not $env:PSModulePath.Contains("${env:ProgramFiles}\WindowsPowerShell\Modules"))
     {
-        $env:PSModulePath += ';C:\Program Files\WindowsPowerShell\Modules'
+        $env:PSModulePath += ";${env:ProgramFiles}\WindowsPowerShell\Modules"
+    }
+    
+    if (-not $env:PSModulePath.Contains("${env:windir}\system32\WindowsPowerShell\v1.0\Modules"))
+    {
+        $env:PSModulePath += ";${env:windir}\system32\WindowsPowerShell\v1.0\Modules"
+    }
+    
+    if (-not $env:PSModulePath.Contains("${env:userprofile}\Documents\WindowsPowerShell\Modules"))
+    {
+        $env:PSModulePath += ";${env:userprofile}\Documents\WindowsPowerShell\Modules"
     }
 }

--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -695,12 +695,12 @@ function Add-WindowsPSModulePath
     }
 
     $paths =  @(
-    $Env:PSModulePath -split [System.IO.Path]::PathSeparator
-    "${Env:UserProfile}\Documents\WindowsPowerShell\Modules"
-    "${Env:ProgramFiles}\WindowsPowerShell\Modules"
-    "${Env:WinDir}\system32\WindowsPowerShell\v1.0\Modules"
-    [System.Environment]::GetEnvironmentVariable('PSModulePath',
-        [System.EnvironmentVariableTarget]::Machine) -split [System.IO.Path]::PathSeparator
+        $Env:PSModulePath -split [System.IO.Path]::PathSeparator
+        "${Env:UserProfile}\Documents\WindowsPowerShell\Modules"
+        "${Env:ProgramFiles}\WindowsPowerShell\Modules"
+        "${Env:WinDir}\system32\WindowsPowerShell\v1.0\Modules"
+        [System.Environment]::GetEnvironmentVariable('PSModulePath',
+            [System.EnvironmentVariableTarget]::Machine) -split [System.IO.Path]::PathSeparator
     )
 
     $pathTable = [ordered] @{}

--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -701,4 +701,8 @@ function Add-WindowsPSModulePath
         $env:PSModulePath += ";${env:userprofile}\Documents\WindowsPowerShell\Modules;${WindowsPSModulePath}"
     }
 
+    if (-not $env:PSModulePath.Contains('C:\Program Files\WindowsPowerShell\Modules'))
+    {
+        $env:PSModulePath += ';C:\Program Files\WindowsPowerShell\Modules'
+    }
 }

--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -684,7 +684,6 @@ function Copy-WinModule
 
 function Add-WindowsPSModulePath
 {
-
     if ($PSVersionTable.PSEdition -eq 'Core' -and -not $IsWindows)
     {
         throw "This cmdlet is only supported on Windows"
@@ -695,18 +694,23 @@ function Add-WindowsPSModulePath
         return
     }
 
-    $Paths = @(
-        "${env:userprofile}\Documents\WindowsPowerShell\Modules"
-        "${env:ProgramFiles}\WindowsPowerShell\Modules"
-        "${env:windir}\system32\WindowsPowerShell\v1.0\Modules"
-        [System.Environment]::GetEnvironmentVariable("PSModulePath", [System.EnvironmentVariableTarget]::Machine) -split [System.IO.Path]::PathSeparator
+    $paths =  @(
+    $Env:PSModulePath -split [System.IO.Path]::PathSeparator
+    "${Env:UserProfile}\Documents\WindowsPowerShell\Modules"
+    "${Env:ProgramFiles}\WindowsPowerShell\Modules"
+    "${Env:WinDir}\system32\WindowsPowerShell\v1.0\Modules"
+    [System.Environment]::GetEnvironmentVariable('PSModulePath',
+        [System.EnvironmentVariableTarget]::Machine) -split [System.IO.Path]::PathSeparator
     )
 
-    foreach ($Path in $Paths)
+    $pathTable = [ordered] @{}
+    foreach ($path in $paths)
     {
-        if (-not $env:PSModulePath.Contains($Path))
+        if ($pathTable[$path])
         {
-            $env:PSModulePath += [System.IO.Path]::PathSeparator + $Path
+            continue
         }
+        $pathTable[$path] = $true
     }
+    $Env:PSModulePath = $pathTable.Keys -join [System.IO.Path]::PathSeparator
 }

--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -706,7 +706,7 @@ function Add-WindowsPSModulePath
     {
         if (-not $env:PSModulePath.Contains($Path))
         {
-            $env:PSModulePath += ";$Path"
+            $env:PSModulePath += [System.IO.Path]::PathSeparator + $Path
         }
     }
 }

--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -695,24 +695,18 @@ function Add-WindowsPSModulePath
         return
     }
 
-    $WindowsPSModulePath = [System.Environment]::GetEnvironmentVariable("PSModulePath", [System.EnvironmentVariableTarget]::Machine)
-    if (-not $env:PSModulePath.Contains($WindowsPSModulePath))
-    {
-        $env:PSModulePath += ";${WindowsPSModulePath}"
-    }
+    $Paths = @(
+        "${env:userprofile}\Documents\WindowsPowerShell\Modules"
+        "${env:ProgramFiles}\WindowsPowerShell\Modules"
+        "${env:windir}\system32\WindowsPowerShell\v1.0\Modules"
+        [System.Environment]::GetEnvironmentVariable("PSModulePath", [System.EnvironmentVariableTarget]::Machine) -split [System.IO.Path]::PathSeparator
+    )
 
-    if (-not $env:PSModulePath.Contains("${env:ProgramFiles}\WindowsPowerShell\Modules"))
+    foreach ($Path in $Paths)
     {
-        $env:PSModulePath += ";${env:ProgramFiles}\WindowsPowerShell\Modules"
-    }
-    
-    if (-not $env:PSModulePath.Contains("${env:windir}\system32\WindowsPowerShell\v1.0\Modules"))
-    {
-        $env:PSModulePath += ";${env:windir}\system32\WindowsPowerShell\v1.0\Modules"
-    }
-    
-    if (-not $env:PSModulePath.Contains("${env:userprofile}\Documents\WindowsPowerShell\Modules"))
-    {
-        $env:PSModulePath += ";${env:userprofile}\Documents\WindowsPowerShell\Modules"
+        if (-not $env:PSModulePath.Contains($Path))
+        {
+            $env:PSModulePath += ";$Path"
+        }
     }
 }

--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -698,7 +698,7 @@ function Add-WindowsPSModulePath
     $WindowsPSModulePath = [System.Environment]::GetEnvironmentVariable("psmodulepath", [System.EnvironmentVariableTarget]::Machine)
     if (-not ($env:PSModulePath).Contains($WindowsPSModulePath))
     {
-        $env:PSModulePath += ";${env:userprofile}\Documents\WindowsPowerShell\Modules;${env:programfiles}\WindowsPowerShell\Modules;${WindowsPSModulePath}"
+        $env:PSModulePath += ";${env:userprofile}\Documents\WindowsPowerShell\Modules;${WindowsPSModulePath}"
     }
 
 }


### PR DESCRIPTION
Since `${env:programfiles}\WindowsPowerShell\Modules` is in PSModulePath machine environment variable, it should not be added twice.