### PR TITLE
Add Add-WinPSModulePath alias.

### DIFF
--- a/WindowsCompatibility/WindowsCompatibility.psd1
+++ b/WindowsCompatibility/WindowsCompatibility.psd1
@@ -30,6 +30,7 @@ FunctionsToExport = @(
     'Copy-WinModule',
     'Add-WindowsPSModulePath'
 )
+AliasesToExport = @('Add-WinPSModulePath')
 PrivateData = @{
     PSData = @{
         Tags = @('Compatibility', 'Core')

--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -93,6 +93,8 @@ $DefaultConfigurationName = 'Microsoft.PowerShell'
 # Specifies the default name of the computer on which to create the compatibility session
 $DefaultComputerName = 'localhost'
 
+Set-Alias -Name Add-WinPSModulePath -Value Add-WindowsPSModulePath
+
 function Initialize-WinSession
 {
     [CmdletBinding()]


### PR DESCRIPTION
Add an `Add-WinPSModulePath` alias for `Add-WindowsPSModulePath` function.
Fix #30 