### PR TITLE
Fix ShouldProcess for Add-WindowsPSModulePath

### DIFF
--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -759,7 +759,7 @@ function Add-WindowsPSModulePath
     )
 
     $pathTable = [ordered] @{}
-    $doUpdate = $false
+
     foreach ($path in $paths)
     {
         if ($pathTable[$path])
@@ -770,14 +770,9 @@ function Add-WindowsPSModulePath
         if ($PSCmdlet.ShouldProcess($path, "Add to PSModulePath"))
         {
             Write-Verbose -Verbose:$verboseFlag "Adding '$path' to the PSModulePath."
-            $doUpdate = $true
+            $pathTable[$path] = $true
         }
-
-        $pathTable[$path] = $true
     }
 
-    if ($doUpdate)
-    {
-        $Env:PSModulePath = $pathTable.Keys -join [System.IO.Path]::PathSeparator
-    }
+    $Env:PSModulePath = $pathTable.Keys -join [System.IO.Path]::PathSeparator
 }


### PR DESCRIPTION
Fix #57 

Now, if use `Add-WinPSModulePath -Confirm` and for some paths specify **[N] No**, and for other paths - **[Y] Yes**, all the paths will be added, including the ones, for which **[N] No** was specified.

