### PR TITLE
Add User PSModulePath environment variable to Add-WindowsPSModulePath function.

### DIFF
--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -755,6 +755,8 @@ function Add-WindowsPSModulePath
         "${Env:ProgramFiles}\WindowsPowerShell\Modules"
         "${Env:WinDir}\system32\WindowsPowerShell\v1.0\Modules"
         [System.Environment]::GetEnvironmentVariable('PSModulePath',
+            [System.EnvironmentVariableTarget]::User) -split [System.IO.Path]::PathSeparator
+        [System.Environment]::GetEnvironmentVariable('PSModulePath',
             [System.EnvironmentVariableTarget]::Machine) -split [System.IO.Path]::PathSeparator
     )
 


### PR DESCRIPTION
Fix #59 

`Add-WindowsPSModulePath` function doesn't account for User **PSModulePath** environment variable.

