### PR TITLE
Fix adding '.WinModule' with every execution of Import-WinModule command if the module is from NeverClobberList

### DIFF
--- a/WindowsCompatibility/WindowsCompatibility.psm1
+++ b/WindowsCompatibility/WindowsCompatibility.psm1
@@ -537,9 +537,12 @@ function Import-WinModule
             {
                 $module = Import-Module -Name $name -NoClobber @importModuleParameters
                 # Hack using private reflection to keep the proxy module from shadowing the real module.
-                $null = [PSModuleInfo].
-                    GetMethod('SetName',[System.Reflection.BindingFlags]'Instance, NonPublic').
-                        Invoke($module, @($module.Name + '.WinModule'))
+                if (-not $module.Name.EndsWith('.WinModule', [System.StringComparison]::InvariantCulture))
+                {
+                    $null = [PSModuleInfo].
+                        GetMethod('SetName',[System.Reflection.BindingFlags]'Instance, NonPublic').
+                            Invoke($module, @($module.Name + '.WinModule'))
+                }
                 if($PassThru.IsPresent)
                 {
                     $module


### PR DESCRIPTION
Fix #64 

Each execution of the `Import-WinModule` adds **.WinModule** to the name of the imported module if the module is from NeverClobberList.

This PR adds check if the name already ends with  **.WinModule**.

